### PR TITLE
options for empty df in filter logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pandahandler"
-version = "0.5.4"
+version = "0.5.5"
 description = "Tools for handling pandas objects."
 authors = [{ name = "Zach Kurtz", email = "zkurtz@gmail.com" }]
 readme = "README.md"
@@ -28,7 +28,7 @@ Source = "https://github.com/zkurtz/pandahandler"
 package = true
 
 [tool.bumpversion]
-current_version = "0.5.4"
+current_version = "0.5.5"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/uv.lock
+++ b/uv.lock
@@ -230,7 +230,7 @@ wheels = [
 
 [[package]]
 name = "pandahandler"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Currently the filtering logger crashes if the output data frame size is zero.

I changed this to not crash by default, simply logging that the output size is zero. However, I also added options to raise errors in case either the input or output data frame is empty